### PR TITLE
Add DVC data prep pipeline

### DIFF
--- a/data_preprocessing/masati/.gitignore
+++ b/data_preprocessing/masati/.gitignore
@@ -1,0 +1,3 @@
+/xml_annotations
+/PNGImages
+/yolo_annotations

--- a/data_preprocessing/masati/.gitignore
+++ b/data_preprocessing/masati/.gitignore
@@ -1,3 +1,5 @@
 /xml_annotations
 /PNGImages
 /yolo_annotations
+/train
+/validation

--- a/data_preprocessing/masati/dvc.lock
+++ b/data_preprocessing/masati/dvc.lock
@@ -30,3 +30,36 @@ get_yolo_labels:
     md5: ba577dbf3e3f8a1894c4c80f57a941cd.dir
     size: 194737
     nfiles: 2368
+split_dataset:
+  cmd: python train_test_split.py
+  deps:
+  - path: PNGImages
+    md5: d751713988987e9331980363e24189ce.dir
+    size: 0
+    nfiles: 0
+  - path: train_test_split.py
+    md5: c1ae4cfc990c168f57eafbd1f49ce9a5
+    size: 3901
+  - path: xml_annotations/
+    md5: cdf1ee07de65a723a88f34c71584ef64.dir
+    size: 1692433
+    nfiles: 2368
+  params:
+    params.yaml:
+      split_dataset.annotations_dir: xml_annotations
+      split_dataset.trainpct: 0.75
+  outs:
+  - path: train/
+    md5: e4224b66e9d70292eb6ee2e36a108e37.dir
+    size: 583774686
+    nfiles: 1776
+  - path: validation/
+    md5: a340ccdfd92b583a884f8154d1034a16.dir
+    size: 198690080
+    nfiles: 592
+  - path: xml_annotations_test.txt
+    md5: cdf8bca749a0bbdfc4d9bff0d94581d8
+    size: 46176
+  - path: xml_annotations_train.txt
+    md5: 94d12da9a4e4045771a54c209206b4a0
+    size: 138528

--- a/data_preprocessing/masati/dvc.lock
+++ b/data_preprocessing/masati/dvc.lock
@@ -1,0 +1,32 @@
+prepare_images:
+  cmd: python refine_masati.py
+  deps:
+  - path: MASATI-v2/
+    md5: 231b4357ae8e029ebcaafce1fe33d7d1.dir
+    size: 1736795071
+    nfiles: 5023
+  outs:
+  - path: PNGImages
+    md5: 88a04b86e52528bec9af55eacd6d4748.dir
+    size: 782464766
+    nfiles: 2368
+  - path: xml_annotations
+    md5: cdf1ee07de65a723a88f34c71584ef64.dir
+    size: 1692433
+    nfiles: 2368
+get_yolo_labels:
+  cmd: python convert_xml_to_yolotxt.py
+  deps:
+  - path: PNGImages/
+    md5: 88a04b86e52528bec9af55eacd6d4748.dir
+    size: 782464766
+    nfiles: 2368
+  - path: xml_annotations/
+    md5: cdf1ee07de65a723a88f34c71584ef64.dir
+    size: 1692433
+    nfiles: 2368
+  outs:
+  - path: yolo_annotations
+    md5: ba577dbf3e3f8a1894c4c80f57a941cd.dir
+    size: 194737
+    nfiles: 2368

--- a/data_preprocessing/masati/dvc.lock
+++ b/data_preprocessing/masati/dvc.lock
@@ -63,3 +63,31 @@ split_dataset:
   - path: xml_annotations_train.txt
     md5: 94d12da9a4e4045771a54c209206b4a0
     size: 138528
+get_json_labels:
+  cmd: python convert_masatixml_to_json_labels.py
+  deps:
+  - path: convert_masatixml_to_json_labels.py
+    md5: 4f46408ef55108429d2b4ffd5d990dcc
+    size: 7894
+  - path: xml_annotations_test.txt
+    md5: cdf8bca749a0bbdfc4d9bff0d94581d8
+    size: 46176
+  - path: xml_annotations_train.txt
+    md5: 94d12da9a4e4045771a54c209206b4a0
+    size: 138528
+  params:
+    params.yaml:
+      get_json_labels.classes:
+      - boat
+      get_json_labels.is_masati: true
+      get_json_labels.output_json_test: annotations_test.json
+      get_json_labels.output_json_train: annotations_train.json
+      get_json_labels.test_labels: xml_annotations_test.txt
+      get_json_labels.train_labels: xml_annotations_train.txt
+  outs:
+  - path: coco_json_annotations/annotations_test.json
+    md5: 585b6f8a11feaa4f16bc19ee40db15e0
+    size: 712255
+  - path: coco_json_annotations/annotations_train.json
+    md5: 16a96b52ed0766ae41bf93774d7c7e24
+    size: 521268

--- a/data_preprocessing/masati/dvc.yaml
+++ b/data_preprocessing/masati/dvc.yaml
@@ -1,0 +1,17 @@
+stages:
+  prepare_images:
+    cmd: python refine_masati.py
+    deps:
+    - MASATI-v2/
+    - refine_masati.py
+    outs:
+    - PNGImages
+    - xml_annotations
+  get_yolo_labels:
+    cmd: python convert_xml_to_yolotxt.py
+    deps:
+    - PNGImages/
+    - xml_annotations/
+    - convert_xml_to_yolotxt.py
+    outs:
+    - yolo_annotations

--- a/data_preprocessing/masati/dvc.yaml
+++ b/data_preprocessing/masati/dvc.yaml
@@ -15,3 +15,17 @@ stages:
     - convert_xml_to_yolotxt.py
     outs:
     - yolo_annotations
+  split_dataset:
+    cmd: python train_test_split.py
+    deps:
+    - PNGImages/
+    - train_test_split.py
+    - xml_annotations/
+    params:
+    - split_dataset.annotations_dir
+    - split_dataset.trainpct
+    outs:
+    - train/
+    - validation/
+    - xml_annotations_test.txt
+    - xml_annotations_train.txt

--- a/data_preprocessing/masati/dvc.yaml
+++ b/data_preprocessing/masati/dvc.yaml
@@ -29,3 +29,19 @@ stages:
     - validation/
     - xml_annotations_test.txt
     - xml_annotations_train.txt
+  get_json_labels:
+    cmd: python convert_masatixml_to_json_labels.py
+    deps:
+    - convert_masatixml_to_json_labels.py
+    - xml_annotations_test.txt
+    - xml_annotations_train.txt
+    params:
+    - get_json_labels.classes
+    - get_json_labels.is_masati
+    - get_json_labels.output_json_test
+    - get_json_labels.output_json_train
+    - get_json_labels.test_labels
+    - get_json_labels.train_labels
+    outs:
+    - coco_json_annotations/annotations_test.json
+    - coco_json_annotations/annotations_train.json

--- a/data_preprocessing/masati/params.yaml
+++ b/data_preprocessing/masati/params.yaml
@@ -1,0 +1,3 @@
+split_dataset:
+  annotations_dir: xml_annotations
+  trainpct: 0.75

--- a/data_preprocessing/masati/params.yaml
+++ b/data_preprocessing/masati/params.yaml
@@ -1,3 +1,10 @@
 split_dataset:
   annotations_dir: xml_annotations
   trainpct: 0.75
+get_json_labels:
+  train_labels: xml_annotations_train.txt
+  test_labels: xml_annotations_test.txt
+  is_masati: True
+  classes: ["boat"]
+  output_json_train: annotations_train.json
+  output_json_test: annotations_test.json

--- a/data_preprocessing/masati/refine_masati.py
+++ b/data_preprocessing/masati/refine_masati.py
@@ -76,8 +76,6 @@ def create_directory_structure(masati_directories, debug=False):
 def main():
     masati_directories = ["xml_annotations", "PNGImages"]
     create_directory_structure(masati_directories)
-        
-        
+
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
Will add a data preparation pipeline from dvc as described [here](https://dvc.org/doc/start/data-pipelines). This *should* enable users to easily reproduce the same data prep steps and visualise the pipeline.