### PR TITLE
Adds extra file structure for YOLO-based labels and images

### DIFF
--- a/data_preprocessing/masati/.gitignore
+++ b/data_preprocessing/masati/.gitignore
@@ -3,3 +3,8 @@
 /yolo_annotations
 /train
 /validation
+/modified_xml_annotations
+/test_yolo_file_structure
+*.tar.gz
+/MASATI-v2
+/temp*

--- a/data_preprocessing/masati/convert_xml_to_yolotxt.py
+++ b/data_preprocessing/masati/convert_xml_to_yolotxt.py
@@ -59,7 +59,7 @@ def convert_xml_annotation_to_yolo(label_path, output_path, is_masati, classes):
 
 def main():
 
-    labels_dir = os.path.join(os.getcwd(), "xml_annotations")
+    labels_dir = os.path.join(os.getcwd(), "modified_xml_annotations")
     classes = ["boat"]
 
     output_path = os.path.join(os.getcwd(), "yolo_annotations")

--- a/data_preprocessing/masati/dvc.lock
+++ b/data_preprocessing/masati/dvc.lock
@@ -5,76 +5,82 @@ prepare_images:
     md5: 231b4357ae8e029ebcaafce1fe33d7d1.dir
     size: 1736795071
     nfiles: 5023
+  - path: refine_masati.py
+    md5: 0e760362fb3c1d22df57ddb6c87529e2
+    size: 3249
   outs:
   - path: PNGImages
-    md5: 88a04b86e52528bec9af55eacd6d4748.dir
+    md5: 910d4c06768d26bb051869e8e4fd81e4.dir
     size: 782464766
     nfiles: 2368
   - path: xml_annotations
-    md5: cdf1ee07de65a723a88f34c71584ef64.dir
+    md5: a790e444d25e6235a30dad22ac30f2ea.dir
     size: 1692433
     nfiles: 2368
 get_yolo_labels:
   cmd: python convert_xml_to_yolotxt.py
   deps:
   - path: PNGImages/
-    md5: 88a04b86e52528bec9af55eacd6d4748.dir
+    md5: 910d4c06768d26bb051869e8e4fd81e4.dir
     size: 782464766
     nfiles: 2368
-  - path: xml_annotations/
-    md5: cdf1ee07de65a723a88f34c71584ef64.dir
-    size: 1692433
+  - path: convert_xml_to_yolotxt.py
+    md5: 83c52cba3349ba653f0e0d6cd6f3b7dc
+    size: 2131
+  - path: modified_xml_annotations/
+    md5: df0b6d762b6600e48ba2db98f72a1077.dir
+    size: 1684474
     nfiles: 2368
   outs:
   - path: yolo_annotations
-    md5: ba577dbf3e3f8a1894c4c80f57a941cd.dir
+    md5: a6c1285f03ab9913484ce4d7c74a0ee0.dir
     size: 194737
     nfiles: 2368
 split_dataset:
   cmd: python train_test_split.py
   deps:
-  - path: PNGImages
+  - path: PNGImages/
     md5: d751713988987e9331980363e24189ce.dir
     size: 0
     nfiles: 0
-  - path: train_test_split.py
-    md5: c1ae4cfc990c168f57eafbd1f49ce9a5
-    size: 3901
-  - path: xml_annotations/
-    md5: cdf1ee07de65a723a88f34c71584ef64.dir
-    size: 1692433
+  - path: modified_xml_annotations/
+    md5: df0b6d762b6600e48ba2db98f72a1077.dir
+    size: 1684474
     nfiles: 2368
+  - path: train_test_split.py
+    md5: 09dcca353f85d750db2de47e2fa24455
+    size: 3918
   params:
     params.yaml:
-      split_dataset.annotations_dir: xml_annotations
+      split_dataset.annotations_dir: modified_xml_annotations
       split_dataset.trainpct: 0.75
   outs:
   - path: train/
-    md5: e4224b66e9d70292eb6ee2e36a108e37.dir
-    size: 583774686
+    md5: 9eb747db5d547d4e564294ea3b28f7ce.dir
+    size: 582037464
     nfiles: 1776
   - path: validation/
-    md5: a340ccdfd92b583a884f8154d1034a16.dir
-    size: 198690080
+    md5: 4e461a23b3d262fa38284e0def67e372.dir
+    size: 200427302
     nfiles: 592
   - path: xml_annotations_test.txt
-    md5: cdf8bca749a0bbdfc4d9bff0d94581d8
-    size: 46176
+    md5: bb0c97ba7d1dc1d9a41f91f3b4a29fc6
+    size: 49728
   - path: xml_annotations_train.txt
-    md5: 94d12da9a4e4045771a54c209206b4a0
-    size: 138528
+    md5: 12eea3094172e490a3ce03e08ae00dca
+    size: 149184
 get_json_labels:
   cmd: python convert_masatixml_to_json_labels.py
   deps:
   - path: convert_masatixml_to_json_labels.py
-    md5: 4f46408ef55108429d2b4ffd5d990dcc
-    size: 7894
+    md5: 3c621ccf70e4406e773c041957a29219
+    size: 8046
   - path: xml_annotations_test.txt
-    md5: cdf8bca749a0bbdfc4d9bff0d94581d8
-    size: 46176
+    md5: bb0c97ba7d1dc1d9a41f91f3b4a29fc6
+    size: 49728
   - path: xml_annotations_train.txt
-    md5: 94d12da9a4e4045771a54c209206b4a0
-    size: 138528
+    md5: 12eea3094172e490a3ce03e08ae00dca
+    size: 149184
   params:
     params.yaml:
       get_json_labels.classes:
@@ -86,8 +92,23 @@ get_json_labels:
       get_json_labels.train_labels: xml_annotations_train.txt
   outs:
   - path: coco_json_annotations/annotations_test.json
-    md5: 585b6f8a11feaa4f16bc19ee40db15e0
-    size: 712255
+    md5: b8bbbd19f4dc3c09f3f6ec8b79ea638b
+    size: 190435
   - path: coco_json_annotations/annotations_train.json
-    md5: 16a96b52ed0766ae41bf93774d7c7e24
-    size: 521268
+    md5: dad0c19c95ea9a4e3db5935730d9dec2
+    size: 519596
+modified_annotations:
+  cmd: python remove_extra_classes.py
+  deps:
+  - path: remove_extra_classes.py
+    md5: cb670759913ba50800fbfc24fb24fa1c
+    size: 1117
+  - path: xml_annotations
+    md5: a790e444d25e6235a30dad22ac30f2ea.dir
+    size: 1692433
+    nfiles: 2368
+  outs:
+  - path: modified_xml_annotations
+    md5: df0b6d762b6600e48ba2db98f72a1077.dir
+    size: 1684474
+    nfiles: 2368

--- a/data_preprocessing/masati/dvc.yaml
+++ b/data_preprocessing/masati/dvc.yaml
@@ -7,11 +7,18 @@ stages:
     outs:
     - PNGImages
     - xml_annotations
+  modified_annotations:
+    cmd: python remove_extra_classes.py
+    deps:
+    - remove_extra_classes.py
+    - xml_annotations
+    outs:
+    - modified_xml_annotations
   get_yolo_labels:
     cmd: python convert_xml_to_yolotxt.py
     deps:
     - PNGImages/
-    - xml_annotations/
+    - modified_xml_annotations/
     - convert_xml_to_yolotxt.py
     outs:
     - yolo_annotations
@@ -20,7 +27,7 @@ stages:
     deps:
     - PNGImages/
     - train_test_split.py
-    - xml_annotations/
+    - modified_xml_annotations/
     params:
     - split_dataset.annotations_dir
     - split_dataset.trainpct
@@ -29,6 +36,18 @@ stages:
     - validation/
     - xml_annotations_test.txt
     - xml_annotations_train.txt
+  get_yolo_train_test_split:
+    cmd: python sort_yolo_images.py
+    deps:
+    - sort_yolo_images.py
+    - yolo_annotations
+    - train/
+    - validation/
+    outs:
+    - yolo_images_train/
+    - yolo_images_validation/
+    - yolo_labels_train/
+    - yolo_labels_validation/
   get_json_labels:
     cmd: python convert_masatixml_to_json_labels.py
     deps:

--- a/data_preprocessing/masati/params.yaml
+++ b/data_preprocessing/masati/params.yaml
@@ -1,5 +1,5 @@
 split_dataset:
-  annotations_dir: xml_annotations
+  annotations_dir: modified_xml_annotations
   trainpct: 0.75
 get_json_labels:
   train_labels: xml_annotations_train.txt

--- a/data_preprocessing/masati/remove_extra_classes.py
+++ b/data_preprocessing/masati/remove_extra_classes.py
@@ -1,0 +1,43 @@
+import os
+import xml.etree.ElementTree as ET
+from tqdm import tqdm as progress_bar
+
+def set_single_class(label_path, output_path, is_masati, classes):
+    basename = os.path.basename(label_path)
+    basename_no_ext = os.path.splitext(basename)[0]
+
+    in_file = open(label_path)
+    out_file = os.path.join(output_path, basename_no_ext + ".xml")
+    tree = ET.parse(in_file)
+    root = tree.getroot()
+
+    size = root.find("size")
+    width = "512"
+    height = "512"
+    root.find("size/width").text = width
+    root.find("size/height").text = height
+
+    for obj in root.iter("object"):
+        obj.find("name").text = "boat"
+
+        
+    tree.write(out_file)
+
+def main():
+
+    labels_dir = os.path.join(os.getcwd(), "xml_annotations")
+    classes = ["boat"]
+
+    output_path = os.path.join(os.getcwd(), "modified_xml_annotations")
+    
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+
+    for label in progress_bar(os.listdir(labels_dir)):
+        set_single_class(
+            os.path.join(labels_dir, label), output_path, True, classes
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/data_preprocessing/masati/sort_yolo_images.py
+++ b/data_preprocessing/masati/sort_yolo_images.py
@@ -1,0 +1,60 @@
+import os 
+import shutil
+from tqdm import tqdm as progress_bar
+"""Rough script for sorting yolo annotations and images files 
+for use with YOLOv3/v5
+"""
+
+
+
+def create_yolo_dirs(imgdir, labeldir):
+
+    output_labels_dir = os.path.join(os.getcwd(), "yolo_labels_"+imgdir)
+    output_images_dir = output_labels_dir.replace("labels","images")
+    
+    if not os.path.exists(output_labels_dir):
+        os.mkdir(output_labels_dir)
+
+    if not os.path.exists(output_images_dir):
+        os.mkdir(output_images_dir)
+
+    if os.path.exists(output_images_dir) and os.path.exists(output_labels_dir):
+        return output_images_dir, output_labels_dir
+       
+        
+    label_list = os.listdir(labeldir)
+    for imgfile in progress_bar(os.listdir(imgdir)):
+        basefile = imgfile.split(".",1)[0]
+        if basefile+".txt" in label_list:
+            shutil.copyfile(os.path.join(os.getcwd(),imgdir,imgfile), os.path.join(output_images_dir, imgfile))
+            shutil.copyfile(os.path.join(os.getcwd(),labeldir,basefile+".txt"), os.path.join(output_labels_dir, basefile+".txt"))
+    return output_images_dir, output_labels_dir
+        
+def rename_yolo_files(label_dir):
+    labels_path = os.path.join(os.getcwd(), label_dir) 
+    counter = 1 
+    for thisfile in progress_bar(os.listdir(labels_path)): 
+     
+        old_label_path = os.path.join(labels_path, thisfile) 
+        old_image_path = old_label_path.replace("labels","images").replace(".txt",".png") 
+        new_label_name = str(counter).zfill(5) 
+        new_label_path = os.path.join(labels_path,new_label_name+".txt") 
+        images_dir = old_image_path.rsplit("/",1)[0] 
+        new_image_name = os.path.join(images_dir,new_label_name+".png") 
+        counter +=1 
+     
+        print(old_label_path, new_label_path, old_image_path,new_image_name) 
+        os.replace(old_label_path,new_label_path) 
+        os.replace(old_image_path, new_image_name) 
+
+
+def main():
+    yolo_annotations_dir = "yolo_annotations"
+    for imgdir in ["train", "validation"]:
+        _, new_label_dir = create_yolo_dirs(imgdir, yolo_annotations_dir)
+        rename_yolo_files(new_label_dir)
+        
+
+        
+if __name__ == "__main__":
+    main()

--- a/data_preprocessing/masati/train_test_split.py
+++ b/data_preprocessing/masati/train_test_split.py
@@ -52,11 +52,10 @@ def output_files(train, test):
     return
 
 
-def move_image_files(train, test):
+def move_image_files(train, test, annotations_dir_name):
     train_dir_name = "train"
     test_dir_name = "validation"
     img_dir_name = "PNGImages"
-    annotations_dir_name = "xml_annotations"
 
     train_img_dir = os.path.join(os.getcwd(), train_dir_name)
     test_img_dir = os.path.join(os.getcwd(), test_dir_name)
@@ -103,7 +102,7 @@ def main():
     train_set, test_set = split_dataset(file_list, params["split_dataset"]["trainpct"])
 
     output_files(train_set, test_set)
-    move_image_files(train_set, test_set)
+    move_image_files(train_set, test_set, xml_annotations_dir)
     return
 
 


### PR DESCRIPTION
Adds file structure for yolo-style annotations in the data prep stage as needed by pytorch recasts of YOLO. Also renames (via a copy not a mv) image files to correspond correctly to the new label files. 

Closes #7 